### PR TITLE
Fix Bayonet entry visibility and modifiers in weapon catalogues

### DIFF
--- a/Melee Weapons.cat
+++ b/Melee Weapons.cat
@@ -179,7 +179,7 @@
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup name="Bayonet" id="aaf9-7a80-a920-1711" hidden="false" flatten="true">
+    <selectionEntryGroup name="Bayonet" id="aaf9-7a80-a920-1711" hidden="false">
       <entryLinks>
         <entryLink import="true" name="Bayonet" hidden="false" id="ca4d-901f-1037-1cb1" type="selectionEntry" targetId="2a56-df62-c8c1-9bc0">
           <costs>

--- a/New Antioch.cat
+++ b/New Antioch.cat
@@ -58,6 +58,11 @@
             <condition type="atLeast" value="1" field="selections" scope="model" childId="4726-6351-efcd-87a1" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="decrement" value="3" field="8c12-2a24-bd1d-ff3d">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="parent" childId="aaf9-7a80-a920-1711" shared="true" childName="Bayonet" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntryGroup>
     <selectionEntryGroup name="Equipment" id="d5c6-bf28-709b-7286" hidden="false">
@@ -860,7 +865,15 @@ For the purpose of Battle Demolition on Combat Engineers, this item counts as a 
     </selectionEntryGroup>
     <selectionEntryGroup name="Melee Weapons" id="20db-0edb-9d5e-17c9" hidden="false">
       <entryLinks>
-        <entryLink import="true" name="Melee (One-Handed)" hidden="false" id="f078-5931-0a72-6dcc" type="selectionEntryGroup" targetId="8118-278a-73e1-1cd0" collective="false" collapsible="true"/>
+        <entryLink import="true" name="Melee (One-Handed)" hidden="false" id="f078-5931-0a72-6dcc" type="selectionEntryGroup" targetId="8118-278a-73e1-1cd0" collective="false" collapsible="true">
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="parent" childId="aaf9-7a80-a920-1711" shared="true" childName="Bayonet"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </entryLink>
         <entryLink import="true" name="Melee (Two-Handed)" hidden="false" id="196d-0066-9adb-ef69" type="selectionEntryGroup" targetId="9a78-862f-67eb-f06b" collapsible="true">
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1c9c-0112-cb28-7e0e" includeChildSelections="false"/>
@@ -958,6 +971,11 @@ For the purpose of Battle Demolition on Combat Engineers, this item counts as a 
               </conditionGroups>
               <comment>stolen from sultans to account for the homonculus</comment>
             </modifier>
+            <modifier type="decrement" value="1" field="1c9c-0112-cb28-7e0e">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="parent" childId="aaf9-7a80-a920-1711" shared="true" childName="Bayonet" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
         </entryLink>
       </entryLinks>
@@ -1047,6 +1065,16 @@ For the purpose of Battle Demolition on Combat Engineers, this item counts as a 
               <conditions>
                 <condition type="atLeast" value="1" field="selections" scope="model" childId="4726-6351-efcd-87a1" shared="true" includeChildSelections="true"/>
               </conditions>
+            </modifier>
+            <modifier type="decrement" value="2" field="1d98-dac9-12f0-e194">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="32a4-70a4-fd79-c4e7" shared="true" childName="Butcher Bayonet" includeChildSelections="true"/>
+                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="2a56-df62-c8c1-9bc0" shared="true" childName="Bayonet" includeChildSelections="true" sortIndex="1"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
         </modifierGroup>

--- a/Ranged Weapons.cat
+++ b/Ranged Weapons.cat
@@ -123,7 +123,7 @@
       </profiles>
       <entryLinks>
         <entryLink import="true" name="Ammunitions" hidden="false" id="2830-5724-08ab-6bd0" type="selectionEntryGroup" targetId="a7db-7c08-54bb-880e"/>
-        <entryLink import="true" name="Bayonet" hidden="false" id="9884-4e95-7451-112b" type="selectionEntryGroup" targetId="aaf9-7a80-a920-1711" sortIndex="-1"/>
+        <entryLink import="true" name="Bayonet" hidden="false" id="9884-4e95-7451-112b" type="selectionEntryGroup" targetId="aaf9-7a80-a920-1711" sortIndex="1"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Flamethrower" hidden="false" id="985f-e0c3-b0e9-5f89">


### PR DESCRIPTION
I would appreciate this being a conversation and brainstorm on the best approach. My idea is to just remove the obvious increments to show that they have been _used_